### PR TITLE
component destroy error fixed

### DIFF
--- a/src/core/JasperDirectiveWrapperFactory.ts
+++ b/src/core/JasperDirectiveWrapperFactory.ts
@@ -27,7 +27,7 @@ module jasper.core {
             }
             // subscribe on scope destroying:
             var onDestroy = function () {
-                if (onNewScopeDestroyed.length) {
+                if (onNewScopeDestroyed && onNewScopeDestroyed.length) {
                     for (var i = 0; i < onNewScopeDestroyed.length; i++) {
                         onNewScopeDestroyed[i]();
                     }


### PR DESCRIPTION
If onNewScopeDestroyed is null it shouldn't use length
